### PR TITLE
Fixed bug in testing nonbatchwise

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^Dockerfile$
+^conda/*\.*$

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
+#R
 .Rproj.user
 .Rhistory
 .RData
 .Ruserdata
-waveica/.Rbuildignore
-waveica/waveica.Rproj
+..Rcheck
+
+#tests
+tests/testthat/test-data
+
+#vscode
+.vscode

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,11 +2,12 @@ Package: recetox.waveica
 Type: Package
 Title: recetox.waveica
 Version: 0.2.0
+Author: Kui Deng and Kang Li
+Maintainer: RECETOX <GalaxyToolsDevelopmentandDeployment@space.muni.cz>
 Authors@R: c(
  person("Kui", "Deng", email="dengkui_stat@163.com", role="aut"),
  person("Kang", "Li", role="aut"),
  person("RECETOX", email = "GalaxyToolsDevelopmentandDeployment@space.muni.cz", role = "cre"))
-Maintainer: RECETOX <GalaxyToolsDevelopmentandDeployment@space.muni.cz>
 Description: Removal of batch effects for large-scale untargeted metabolomics data based on wavelet transform. This is a customized fork of the original WaveICA package that contains both WaveICA and WaveICA 2.0.
 License: MIT
 Encoding: UTF-8
@@ -18,4 +19,6 @@ Suggests:
     patrick,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
+Depends: 
+    R (>= 3.5.0)
 RoxygenNote: 7.1.2

--- a/conda/environment-dev.yaml
+++ b/conda/environment-dev.yaml
@@ -12,3 +12,4 @@ dependencies:
   - r-devtools
   - r-patrick
   - r-dplyr
+  - r-languageserver

--- a/tests/testthat/test_nonbatchwise_waveica.R
+++ b/tests/testthat/test_nonbatchwise_waveica.R
@@ -4,7 +4,7 @@ patrick::with_parameters_test_that(
     input_data_path <- file.path("test-data", test_input)
     input_data <- readRDS(input_data_path)
 
-    injection_order <- dplyr::select(input_data, injectionOrder)
+    injection_order <- as.integer(input_data$injectionOrder)
     input_data <- dplyr::select(input_data, -any_of(c("sampleName", "injectionOrder", "sampleType", "batch", "class")))
 
     actual <- waveica_nonbatchwise(


### PR DESCRIPTION
When reading the injection order information, the tool created a dataframe with a single column. This passes under linux and mac due to the parallel processing package but actually failed (correctly) on windows.

This fixes reading the dataframe for the test.

Closes #5 
Closes #6 